### PR TITLE
Add isolated network shared secret support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - in case of vulnerabilities.
 -->
 
+## [Unreleased]
+
+### Added
+
+* Support for isolated networks secured by a shared secret. Nodes configured with the shared secret only connect to other members of the isolated network and refuse to bridge to the public mesh.
+
 ## [0.5.12] - 2024-12-18
 
 * Go 1.22 is now required to build Yggdrasil

--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -204,6 +204,9 @@ func main() {
 				return !iprange.Contains(ip)
 			}),
 		}
+		if cfg.IsolatedNetwork.Enabled {
+			options = append(options, core.SharedSecret([]byte(cfg.IsolatedNetwork.SharedSecret)))
+		}
 		for _, addr := range cfg.Listen {
 			options = append(options, core.ListenAddress(addr))
 		}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/hjson/hjson-go/v4"
+	"golang.org/x/crypto/blake2b"
 	"golang.org/x/text/encoding/unicode"
 )
 
@@ -54,6 +55,14 @@ type NodeConfig struct {
 	LogLookups          bool                       `json:",omitempty"`
 	NodeInfoPrivacy     bool                       `comment:"By default, nodeinfo contains some defaults including the platform,\narchitecture and Yggdrasil version. These can help when surveying\nthe network and diagnosing network routing problems. Enabling\nnodeinfo privacy prevents this, so that only items specified in\n\"NodeInfo\" are sent back if specified."`
 	NodeInfo            map[string]interface{}     `comment:"Optional nodeinfo. This must be a { \"key\": \"value\", ... } map\nor set as null. This is entirely optional but, if set, is visible\nto the whole network on request."`
+	IsolatedNetwork     IsolatedNetworkConfig      `comment:"Settings for running this node as part of an isolated network."`
+}
+
+// IsolatedNetworkConfig controls the behaviour of a node that should only
+// connect to other nodes within the same isolated overlay.
+type IsolatedNetworkConfig struct {
+	Enabled      bool   `comment:"Set to true to require a shared secret for all peerings so that this node only joins the isolated network."`
+	SharedSecret string `json:",omitempty" comment:"Shared secret string for isolated networks. Must match other nodes and be at most 64 bytes."`
 }
 
 type MulticastInterfaceConfig struct {
@@ -83,6 +92,7 @@ func GenerateConfig() *NodeConfig {
 	cfg.IfName = defaults.DefaultIfName
 	cfg.IfMTU = defaults.DefaultIfMTU
 	cfg.NodeInfoPrivacy = false
+	cfg.IsolatedNetwork = IsolatedNetworkConfig{}
 	if err := cfg.postprocessConfig(); err != nil {
 		panic(err)
 	}
@@ -147,6 +157,28 @@ func (cfg *NodeConfig) postprocessConfig() error {
 		// was parsed.
 		if err := cfg.GenerateSelfSignedCertificate(); err != nil {
 			return err
+		}
+	}
+
+	if cfg.IsolatedNetwork.SharedSecret != "" && !cfg.IsolatedNetwork.Enabled {
+		cfg.IsolatedNetwork.Enabled = true
+	}
+	if cfg.IsolatedNetwork.Enabled {
+		if cfg.IsolatedNetwork.SharedSecret == "" {
+			return fmt.Errorf("isolated network enabled but no shared secret configured")
+		}
+		if len(cfg.IsolatedNetwork.SharedSecret) > blake2b.Size {
+			return fmt.Errorf("isolated network shared secret must be at most %d bytes", blake2b.Size)
+		}
+		for i := range cfg.MulticastInterfaces {
+			switch cfg.MulticastInterfaces[i].Password {
+			case "":
+				cfg.MulticastInterfaces[i].Password = cfg.IsolatedNetwork.SharedSecret
+			case cfg.IsolatedNetwork.SharedSecret:
+				// Already matches the shared secret.
+			default:
+				return fmt.Errorf("multicast interface %q password must match isolated network shared secret", cfg.MulticastInterfaces[i].Regex)
+			}
 		}
 	}
 	return nil

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -28,15 +28,16 @@ type Core struct {
 	// guarantee that it will be covered by the mutex
 	phony.Inbox
 	*iwe.PacketConn
-	ctx          context.Context
-	cancel       context.CancelFunc
-	secret       ed25519.PrivateKey
-	public       ed25519.PublicKey
-	links        links
-	proto        protoHandler
-	log          Logger
-	addPeerTimer *time.Timer
-	config       struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	secret        ed25519.PrivateKey
+	public        ed25519.PublicKey
+	networkSecret []byte
+	links         links
+	proto         protoHandler
+	log           Logger
+	addPeerTimer  *time.Timer
+	config        struct {
 		tls *tls.Config // immutable after startup
 		//_peers             map[Peer]*linkInfo         // configurable after startup
 		_listeners         map[ListenAddress]struct{} // configurable after startup

--- a/src/core/core_test.go
+++ b/src/core/core_test.go
@@ -46,6 +46,20 @@ func require_True(t *testing.T, a bool) {
 	}
 }
 
+func createNodeWithSharedSecret(t testing.TB, secret string) *Core {
+	cfg := config.GenerateConfig()
+	logger := GetLoggerWithPrefix("", false)
+	opts := []SetupOption{}
+	if secret != "" {
+		opts = append(opts, SharedSecret([]byte(secret)))
+	}
+	node, err := New(cfg.Certificate, logger, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return node
+}
+
 // CreateAndConnectTwo creates two nodes. nodeB connects to nodeA.
 // Verbosity flag is passed to logger.
 func CreateAndConnectTwo(t testing.TB, verbose bool) (nodeA *Core, nodeB *Core) {
@@ -95,6 +109,54 @@ func CreateAndConnectTwo(t testing.TB, verbose bool) (nodeA *Core, nodeB *Core) 
 	}
 
 	return nodeA, nodeB
+}
+
+func TestSharedSecretAllowsConnections(t *testing.T) {
+	nodeA := createNodeWithSharedSecret(t, "shared-secret")
+	t.Cleanup(nodeA.Stop)
+	nodeB := createNodeWithSharedSecret(t, "shared-secret")
+	t.Cleanup(nodeB.Stop)
+
+	listenURL, err := url.Parse("tcp://localhost:0")
+	require_NoError(t, err)
+	listener, err := nodeA.Listen(listenURL, "")
+	require_NoError(t, err)
+	t.Cleanup(listener.Cancel)
+
+	dialURL, err := url.Parse("tcp://" + listener.Addr().String())
+	require_NoError(t, err)
+	require_NoError(t, nodeB.CallPeer(dialURL, ""))
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(nodeA.GetPeers()) == 1 && len(nodeB.GetPeers()) == 1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("expected nodes to connect with shared secret; peers: %d %d", len(nodeA.GetPeers()), len(nodeB.GetPeers()))
+}
+
+func TestSharedSecretBlocksMismatchedNodes(t *testing.T) {
+	nodeA := createNodeWithSharedSecret(t, "shared-secret")
+	t.Cleanup(nodeA.Stop)
+	nodeB := createNodeWithSharedSecret(t, "")
+	t.Cleanup(nodeB.Stop)
+
+	listenURL, err := url.Parse("tcp://localhost:0")
+	require_NoError(t, err)
+	listener, err := nodeA.Listen(listenURL, "")
+	require_NoError(t, err)
+	t.Cleanup(listener.Cancel)
+
+	dialURL, err := url.Parse("tcp://" + listener.Addr().String())
+	require_NoError(t, err)
+	require_NoError(t, nodeB.CallPeer(dialURL, ""))
+
+	time.Sleep(200 * time.Millisecond)
+	if len(nodeA.GetPeers()) != 0 || len(nodeB.GetPeers()) != 0 {
+		t.Fatalf("unexpected peers established without matching secret: %d %d", len(nodeA.GetPeers()), len(nodeB.GetPeers()))
+	}
 }
 
 // WaitConnected blocks until either nodes negotiated DHT or 5 seconds passed.

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -151,6 +151,7 @@ const ErrLinkNotConfigured = linkError("peer is not configured")
 const ErrLinkPriorityInvalid = linkError("priority value is invalid")
 const ErrLinkPinnedKeyInvalid = linkError("pinned public key is invalid")
 const ErrLinkPasswordInvalid = linkError("invalid password supplied")
+const ErrLinkPasswordMismatch = linkError("password does not match isolated network shared secret")
 const ErrLinkUnrecognisedSchema = linkError("link schema unknown")
 const ErrLinkMaxBackoffInvalid = linkError("max backoff duration invalid")
 const ErrLinkSNINotSupported = linkError("SNI not supported on this link type")
@@ -199,6 +200,13 @@ func (l *links) add(u *url.URL, sintf string, linkType linkType) error {
 				return
 			}
 			options.password = []byte(p)
+		}
+		if secret := l.core.networkSecret; len(secret) > 0 {
+			if len(options.password) > 0 && !bytes.Equal(options.password, secret) {
+				retErr = ErrLinkPasswordMismatch
+				return
+			}
+			options.password = secret
 		}
 		if p := u.Query().Get("maxbackoff"); p != "" {
 			d, err := time.ParseDuration(p)
@@ -479,6 +487,12 @@ func (l *links) listen(u *url.URL, sintf string, local bool) (*Listener, error) 
 			return nil, ErrLinkPasswordInvalid
 		}
 		options.password = []byte(p)
+	}
+	if secret := l.core.networkSecret; len(secret) > 0 {
+		if len(options.password) > 0 && !bytes.Equal(options.password, secret) {
+			return nil, ErrLinkPasswordMismatch
+		}
+		options.password = secret
 	}
 
 	phony.Block(l, func() {

--- a/src/core/options.go
+++ b/src/core/options.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+
+	"golang.org/x/crypto/blake2b"
 )
 
 func (c *Core) _applyOption(opt SetupOption) (err error) {
@@ -35,6 +37,15 @@ func (c *Core) _applyOption(opt SetupOption) (err error) {
 		pk := [32]byte{}
 		copy(pk[:], v)
 		c.config._allowedPublicKeys[pk] = struct{}{}
+	case SharedSecret:
+		if len(v) > blake2b.Size {
+			return fmt.Errorf("shared secret must be at most %d bytes", blake2b.Size)
+		}
+		if len(v) == 0 {
+			c.networkSecret = nil
+		} else {
+			c.networkSecret = append([]byte(nil), v...)
+		}
 	}
 	return
 }
@@ -52,6 +63,7 @@ type NodeInfo map[string]interface{}
 type NodeInfoPrivacy bool
 type AllowedPublicKey ed25519.PublicKey
 type PeerFilter func(net.IP) bool
+type SharedSecret []byte
 
 func (a ListenAddress) isSetupOption()    {}
 func (a Peer) isSetupOption()             {}
@@ -59,3 +71,4 @@ func (a NodeInfo) isSetupOption()         {}
 func (a NodeInfoPrivacy) isSetupOption()  {}
 func (a AllowedPublicKey) isSetupOption() {}
 func (a PeerFilter) isSetupOption()       {}
+func (a SharedSecret) isSetupOption()     {}


### PR DESCRIPTION
## Summary
- add isolated network configuration with a shared secret in node configs and defaults
- enforce the shared secret across all peering links so nodes cannot bridge to other networks
- update CLI wiring, changelog, and add tests covering successful and rejected connections

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ce327b49448325b208c75b33b4341b